### PR TITLE
cognify: update function signature to accept dataset_name instead of ids

### DIFF
--- a/cogwit_sdk/cogwit/cogwit.py
+++ b/cogwit_sdk/cogwit/cogwit.py
@@ -88,7 +88,7 @@ class cogwit:
     async def add(
         self,
         data: Union[List[str], str],
-        dataset_name: str,
+        dataset_name: str = "main_dataset",
         dataset_id: Optional[UUID] = None,
         node_set: Optional[List[str]] = None,
     ) -> Union[AddResponse, AddError]:
@@ -102,7 +102,7 @@ class cogwit:
             {
                 "text_data": data if isinstance(data, list) else [data],
                 "dataset_id": dataset_id or "",
-                "dataset_name": dataset_name or "",
+                "dataset_name": dataset_name,
                 "node_set": node_set,
             },
         )
@@ -122,7 +122,7 @@ class cogwit:
 
     async def cognify(
         self,
-        dataset_name: str,
+        datasets: List[str] = ["main_dataset"],
         temporal_cognify: bool = False,
     ) -> Union[CognifyResponse, CognifyError]:
         response_data = await send_api_request(
@@ -133,7 +133,7 @@ class cogwit:
                 "Content-Type": "application/json",
             },
             {
-                "datasets": [dataset_name],
+                "datasets": [dataset_name for dataset_name in datasets],
                 "temporal_cognify": temporal_cognify,
             },
         )
@@ -156,7 +156,9 @@ class cogwit:
                 error=response_data.error,
             )
 
-    async def memify(self) -> Union[MemifyResponse, MemifyError]:
+    async def memify(
+        self, dataset_name: str = "main_dataset"
+    ) -> Union[MemifyResponse, MemifyError]:
         response_data = await send_api_request(
             "/memify",
             "post",
@@ -164,7 +166,9 @@ class cogwit:
                 "X-Api-Key": self.config.api_key,
                 "Content-Type": "application/json",
             },
-            {},
+            {
+                "dataset": dataset_name,  # cognee.memify uses dataset not dataset_name, but using dataset_name for consistency with cogwit.add
+            },
         )
 
         if isinstance(response_data, SuccessResponse):

--- a/cogwit_sdk/cogwit/cogwit.py
+++ b/cogwit_sdk/cogwit/cogwit.py
@@ -122,7 +122,7 @@ class cogwit:
 
     async def cognify(
         self,
-        dataset_names: List[str] = ["main_dataset"],
+        datasets: List[str] = ["main_dataset"],
         dataset_ids: List[UUID] = [],
         temporal_cognify: bool = False,
     ) -> Union[CognifyResponse, CognifyError]:
@@ -134,7 +134,7 @@ class cogwit:
                 "Content-Type": "application/json",
             },
             {
-                "datasets": dataset_names,
+                "datasets": datasets,
                 "dataset_ids": dataset_ids,
                 "temporal_cognify": temporal_cognify,
             },

--- a/cogwit_sdk/cogwit/cogwit.py
+++ b/cogwit_sdk/cogwit/cogwit.py
@@ -122,7 +122,8 @@ class cogwit:
 
     async def cognify(
         self,
-        datasets: List[str] = ["main_dataset"],
+        dataset_names: List[str] = ["main_dataset"],
+        dataset_ids: List[UUID] = [],
         temporal_cognify: bool = False,
     ) -> Union[CognifyResponse, CognifyError]:
         response_data = await send_api_request(
@@ -133,7 +134,8 @@ class cogwit:
                 "Content-Type": "application/json",
             },
             {
-                "datasets": [dataset_name for dataset_name in datasets],
+                "datasets": dataset_names,
+                "dataset_ids": dataset_ids,
                 "temporal_cognify": temporal_cognify,
             },
         )
@@ -167,7 +169,7 @@ class cogwit:
                 "Content-Type": "application/json",
             },
             {
-                "dataset": dataset_name,  # cognee.memify uses dataset not dataset_name, but using dataset_name for consistency with cogwit.add
+                "dataset_name": dataset_name,
             },
         )
 

--- a/cogwit_sdk/cogwit/cogwit.py
+++ b/cogwit_sdk/cogwit/cogwit.py
@@ -122,7 +122,7 @@ class cogwit:
 
     async def cognify(
         self,
-        dataset_ids: List[UUID],
+        dataset_name: str,
         temporal_cognify: bool = False,
     ) -> Union[CognifyResponse, CognifyError]:
         response_data = await send_api_request(
@@ -133,7 +133,7 @@ class cogwit:
                 "Content-Type": "application/json",
             },
             {
-                "dataset_ids": dataset_ids,
+                "datasets": [dataset_name],
                 "temporal_cognify": temporal_cognify,
             },
         )

--- a/cogwit_sdk/responses.py
+++ b/cogwit_sdk/responses.py
@@ -1,8 +1,8 @@
 from .cogwit.cogwit import (
-    AddResponse,
-    CognifyResponse,
-    SearchResponse,
-    CombinedSearchResult,
-    SearchResult,
-    SearchResultDataset,
+    AddResponse,  # noqa: F401
+    CognifyResponse,  # noqa: F401
+    SearchResponse,  # noqa: F401
+    CombinedSearchResult,  # noqa: F401
+    SearchResult,  # noqa: F401
+    SearchResultDataset,  # noqa: F401
 )

--- a/tests/end-to-end/use_cogwit_sdk_test.py
+++ b/tests/end-to-end/use_cogwit_sdk_test.py
@@ -1,3 +1,4 @@
+import asyncio
 import os
 from cogwit_sdk import cogwit, CogwitConfig
 from cogwit_sdk.responses import (
@@ -76,7 +77,5 @@ async def main():
     assert search_result.result
     assert search_result.result[0]["text"] == "Test data"
 
-
-import asyncio
 
 asyncio.run(main())


### PR DESCRIPTION
SDK requires arguments, which needs explicitly passing these.

To reduce user friction (+ unblock cognify), adding default params

<img width="1309" height="379" alt="image" src="https://github.com/user-attachments/assets/cd791dca-c632-4796-8a48-1231b0d61066" />
